### PR TITLE
Control keyboard brightness with SHIFT + display brightness keys

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -15,6 +15,10 @@ bindeld = ALT, XF86AudioLowerVolume, Volume down precise, exec, $osdclient --out
 bindeld = ALT, XF86MonBrightnessUp, Brightness up precise, exec, $osdclient --brightness +1
 bindeld = ALT, XF86MonBrightnessDown, Brightness down precise, exec, $osdclient --brightness -1
 
+# Keyboard backlight with Shift modifier
+bindeld = SHIFT, XF86MonBrightnessUp, Keyboard backlight up, exec, brightnessctl --device=kbd_backlight set +5%
+bindeld = SHIFT, XF86MonBrightnessDown, Keyboard backlight down, exec, brightnessctl --device=kbd_backlight set 5%-
+
 # Requires playerctl
 bindld = , XF86AudioNext, Next track, exec, $osdclient --playerctl next
 bindld = , XF86AudioPause, Pause, exec, $osdclient --playerctl play-pause


### PR DESCRIPTION
There is an issue opened in original Omarchy repo https://github.com/basecamp/omarchy/pull/2331

Seems like M series do not have the issue with different `kbd_backlight` device names.
(Not 100% sure, I only have M2 Air available)

I suggest to use `shift` + display brightness keys as there are no dedicated buttons.

There is no need for precise controls, 5% should be "enough for everyone" :)