### PR TITLE
fix: fuzzell config typo remove space befor exec in fields

### DIFF
--- a/config/fuzzel/fuzzel.ini
+++ b/config/fuzzel/fuzzel.ini
@@ -5,7 +5,7 @@ launch-prefix=uwsm app --
 font=JetBrainsMono NF SemiBold:size=14
 use-bold=yes
 dpi-aware=no
-fields=name,generic,comment,categories,filename,keywords, exec
+fields=name,generic,comment,categories,filename,keywords,exec
 terminal=foot
 prompt=""
 placeholder=" Search..."


### PR DESCRIPTION
Fix: Remove space before exec in fuzzel config fields

The extra space in "keywords, exec" causes fuzzel to fail parsing
with "invalid field name" error. Changed to "keywords,exec".

```bash
 err: config.c:846: /home/mike/.config/fuzzel/fuzzel.ini:8: [main].fields: name,generic,comment,categories,filename,keywords, exec: invalid field name " exec", must be one of: "filename", "name", "generic", "exec", "categories", "keywords", "comment"
```