### PR TITLE
support for built-in keyboard backlight keys

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -18,6 +18,11 @@ bindeld = ALT, XF86MonBrightnessDown, Brightness down precise, exec, $osdclient 
 # Keyboard backlight with Shift modifier
 bindeld = SHIFT, XF86MonBrightnessUp, Keyboard backlight up, exec, brightnessctl --device=kbd_backlight set +5%
 bindeld = SHIFT, XF86MonBrightnessDown, Keyboard backlight down, exec, brightnessctl --device=kbd_backlight set 5%-
+# Keyboard backlight with default backlight keys
+bindeld = , XF86KbdBrightnessDown, Keyboard backlight down, exec, brightnessctl --device=kbd_backlight set 5%-
+bindeld = , XF86KbdBrightnessUp, Keyboard backlight up, exec, brightnessctl --device=kbd_backlight set +5%
+
+
 
 # Requires playerctl
 bindld = , XF86AudioNext, Next track, exec, $osdclient --playerctl next


### PR DESCRIPTION
Added binds to enable the default keyboard backlight keys (Touchbar model img for reference).  Should also work on other models.

Kept the SHIFT configuration from the previous PR. 

<br>

![Keyboard Backlight Keys](https://github.com/user-attachments/assets/9576d6dc-9b68-447b-ad45-e5715f36b75a)
