### PR TITLE
Gestures, Right click & Screenshot

### DIFF
--- a/default/hypr/bindings/media.conf
+++ b/default/hypr/bindings/media.conf
@@ -32,3 +32,11 @@ bindld = , XF86AudioPrev, Previous track, exec, $osdclient --playerctl previous
 
 # Switch audio output with Super + Mute
 bindld = SUPER, XF86AudioMute, Switch audio output, exec, omarchy-cmd-audio-switch
+
+
+# Remapping Screenshot and Record (default keys still work without any conflict)
+bindd = SUPER, F12, Screenshot Display, exec, omarchy-cmd-screenshot output
+bindd = SUPER, F11, Screenshot Region, exec, omarchy-cmd-screenshot
+bindd = SUPER, F10, Screenshot Window, exec, omarchy-cmd-screenshot window
+
+

--- a/default/hypr/input.conf
+++ b/default/hypr/input.conf
@@ -12,5 +12,21 @@ input {
 
     touchpad {
         natural_scroll = true
+        clickfinger_behavior = true # Use two-finger clicks for right-click instead of lower-right corner
     }
 }
+
+# Enable touchpad gestures for changing workspacepaces
+gestures {
+  workspace_swipe = true
+  workspace_swipe_min_fingers = 3
+  #workspace_swipe_create_new = true  # uncomment to create a new workspace when swiping right from the last one
+  workspace_swipe_cancel_ratio = 0.0
+  workspace_swipe_direction_lock = true
+  workspace_swipe_direction_lock_threshold = 1
+}
+
+animations {
+  animation = workspaces, 1, 8, default, slidefade 80% # if you want faster/slower animations change the %
+  workspace_wraparound = true # loop through workspaces. this only works with workspace_swipe_create_new set to false or commented out.
+  }


### PR DESCRIPTION
Added support for gestures to swipe between workspaces.

Added two-finger right click setting.

Added new binds for Screenshots for keyboards that don't have a Print key.