### PR TITLE
Fix kernel comparison

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
+if [ "$(uname -r | sed 's/-arch//I')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
   gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then


### PR DESCRIPTION
Changes sed to be case insensitive
Also changes string replace logic, now replaces with NULL instead of '.arch' This should be more in line with how pacman -Q linux reports the kernel Basically, reboot prompt should no longer appear saying that the kernel updated when the kernel didn't update