### PR TITLE
Fix kernel update check for Asahi Linux

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(uname -r | sed 's/-arch/\.arch/')" != "$(pacman -Q linux | awk '{print $2}')" ]; then
+if [ "$(uname -r | sed 's/-asahi-/.asahi/; s/-ARCH$//')" != "$(pacman -Q linux-asahi | awk '{print $2}')" ]; then
   gum confirm "Linux kernel has been updated. Reboot?" && omarchy-state clear re*-required && sudo reboot now
 
 elif [ -f "$HOME/.local/state/omarchy/reboot-required" ]; then


### PR DESCRIPTION
I tested the `omarchy-update-restart` script with Asahi Linux and fixed the bug where it always showed "new kernel update available".

**The issue:** The original script checked for `linux` package, but Asahi uses `linux-asahi` with different version formatting:
- Running kernel: `6.16.8-asahi-1-2-ARCH`
- Package version: `6.16.8.asahi1-2`
