### PR TITLE
Installer/Update Bug fixes

### DIFF
--- a/bin/omarchy-install-vscode
+++ b/bin/omarchy-install-vscode
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Installing VSCode..."
-omarchy-pkg-add visual-studio-code-bin
+yay -S --noconfirm --answerdiff=N visual-studio-code-bin
 
 mkdir -p ~/.vscode ~/.config/Code/User
 

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -6,21 +6,14 @@ set -e
 # Requires manually installing the good package using sudo pacman -U <url>
 ignored_packages=$(omarchy-pkg-ignored)
 
-echo -e "\e[32m\nUpdate system packages\e[0m"
-[[ -n $ignored_packages ]] && echo "sudo pacman -Syu --noconfirm --ignore \"$ignored_packages\""
-sudo pacman -Syu --noconfirm --ignore "$ignored_packages"
-
-# Update AUR packages if any are installed
-if pacman -Qem >/dev/null; then
-  if omarchy-pkg-aur-accessible; then
-    echo -e "\e[32m\nUpdate AUR packages\e[0m"
-    [[ -n $ignored_packages ]] && echo "yay -Sua --noconfirm  --ignore \"$ignored_packages\""
-    yay -Sua --noconfirm --ignore "$ignored_packages"
-    echo
-  else
-    echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"
-    echo
-  fi
+echo -e "\e[32m\nUpdate system packages (including AUR)\e[0m"
+if omarchy-pkg-aur-accessible; then
+  [[ -n $ignored_packages ]] && echo "yay -Syu --noconfirm --ignore \"$ignored_packages\""
+  yay -Syu --noconfirm --ignore "$ignored_packages"
+  echo
+else
+  echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"
+  echo
 fi
 
 orphans=$(pacman -Qtdq || true)

--- a/default/hypr/bindings/clipboard.conf
+++ b/default/hypr/bindings/clipboard.conf
@@ -1,0 +1,5 @@
+# Copy / Paste
+bindd = SUPER, C, Universal copy, sendshortcut, CTRL, Insert,
+bindd = SUPER, V, Universal paste, sendshortcut, SHIFT, Insert,
+bindd = SUPER, X, Universal cut, sendshortcut, CTRL, X,
+bindd = SUPER CTRL, V, Clipboard manager, exec, omarchy-launch-walker -m clipboard


### PR DESCRIPTION
- Fixed the vscode installer to use yay so it can find the package.
- Added the missing clipboard.conf from upstream
- Modified omarchy-update-system-pkgs to use only ``yay`` for full system upgrade which fixes a race condition that resulted in ``xdg-terminal-exec command not found`` and hyperutil conflicts on update.