### PR TITLE
Fix: screensaver rely on new TTE 0.14.1 settings

### DIFF
--- a/bin/omarchy-cmd-screensaver
+++ b/bin/omarchy-cmd-screensaver
@@ -19,11 +19,12 @@ hyprctl keyword cursor:invisible true &>/dev/null
 
 while true; do
   tte -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --anchor-canvas c --anchor-text c\
-    --no-eol --no-restore-cursor random_effect &
+    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
+    --random-effect --exclude-effects dev_worm \
+    --no-eol --no-restore-cursor &
 
   while pgrep -x tte >/dev/null; do
-    if read -n 1 -t 3 || ! screensaver_in_focus; then
+    if read -n 1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi
   done


### PR DESCRIPTION
Replaced bin/omarchy-cmd-screensaver with the current version form the original omarchy 3.2 repo