### PR TITLE
Fix battery detection for Apple Silicon

### DIFF
--- a/bin/omarchy-battery-remaining
+++ b/bin/omarchy-battery-remaining
@@ -2,7 +2,7 @@
 
 # Returns the battery percentage remaining as an integer.
 
-upower -i $(upower -e | grep BAT) \
+upower -i $(upower -e | grep -E "battery_|BAT") \
 | awk -F: '/percentage/ {
     gsub(/[%[:space:]]/, "", $2);
     val=$2;


### PR DESCRIPTION
### Problem

`Super + Ctrl + B` shows "Battery is at %" with no percentage.

### Cause

The `omarchy-battery-remaining` script uses `upower -e | grep BAT` to find the battery, but on Apple Silicon Macs the battery is named `macsmc-battery`:

```
/org/freedesktop/UPower/devices/battery_macsmc_battery
```

Since this doesn't contain `BAT`, the grep returns empty and no percentage is displayed.

### Fix

Changed `grep BAT` to `grep -E "battery_|BAT"` to match Apple Silicon batteries while maintaining compatibility with other systems.

### Tested on

Apple MacBook Pro (14-inch, M1 Pro, 2021)