### PR TITLE
fix everforst theme typo causing error with ghostty

### DIFF
--- a/themes/everforest/ghostty.conf
+++ b/themes/everforest/ghostty.conf
@@ -1,1 +1,1 @@
-theme = Everforest Dark   Hard
+theme = Everforest Dark Hard


### PR DESCRIPTION
Fix a minor issue in the Everforest theme that caused a Ghostty error when switching to it.
This uses the same fix already applied in Omarchy.