### PR TITLE
Fix: Add missing Package handler in remove menu

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -430,6 +430,7 @@ show_install_elixir_menu() {
 
 show_remove_menu() {
   case "$(menu "Remove" $'󰣇  Package\n  Web App\n  TUI\n󰸌  Theme\n󰍲  Windows\n󰈷  Fingerprint\n  Fido2')" in
+  *Package*) terminal omarchy-pkg-remove ;;
   *Web*) present_terminal omarchy-webapp-remove ;;
   *TUI*) present_terminal omarchy-tui-remove ;;
   *Theme*) present_terminal omarchy-theme-remove ;;


### PR DESCRIPTION
Fixes #108 - Selecting 'Package' in Remove menu now correctly calls omarchy-pkg-remove instead of falling through to main menu.