### PR TITLE
Fix emoji picker

### DIFF
--- a/bin/omarchy-emoji-picker
+++ b/bin/omarchy-emoji-picker
@@ -1,39 +1,39 @@
 #!/bin/bash
 # Emoji picker using fuzzel
-# Fallback to basic emoji list if no advanced picker is available
+# Uses official emoji list from unicode.org, cache it & parse to fuzzel
+# Written originally by George Dobreff
 
-# Basic emoji list - you can expand this or use a more comprehensive source
-EMOJIS="😀 😃 😄 😁 😆 😅 😂 🤣 😊 😇
-🙂 🙃 😉 😌 😍 🥰 😘 😗 😙 😚
-😋 😛 😝 😜 🤪 🤨 🧐 🤓 😎 🤩
-🥳 😏 😒 😞 😔 😟 😕 🙁 ☹️ 😣
-😖 😫 😩 🥺 😢 😭 😤 😠 😡 🤬
-🤯 😳 🥵 🥶 😱 😨 😰 😥 😓 🤗
-🤔 🤭 🤫 🤥 😶 😐 😑 😬 🙄 😯
-😦 😧 😮 😲 🥱 😴 🤤 😪 😵 🤐
-🥴 🤢 🤮 🤧 😷 🤒 🤕 🤑 🤠 😈
-👿 👹 👺 🤡 💩 👻 💀 ☠️ 👽 👾
-🤖 🎃 😺 😸 😹 😻 😼 😽 🙀 😿
-😾 👋 🤚 🖐️ ✋ 🖖 👌 🤌 🤏 ✌️
-🤞 🤟 🤘 🤙 👈 👉 👆 🖕 👇 ☝️
-👍 👎 👊 ✊ 🤛 🤜 👏 🙌 👐 🤲
-🤝 🙏 ✍️ 💅 🤳 💪 🦾 🦿 🦵 🦶
-👂 🦻 👃 🧠 🫀 🫁 🦷 🦴 👀 👁️
-👅 👄 💋 🩸 👶 🧒 👦 👧 🧑 👱
-👨 🧔 👩 🧓 👴 👵 🙍 🙎 🙅 🙆
-💁 🙋 🧏 🙇 🤦 🤷 👮 🕵️ 💂 🥷
-👷 🤴 👸 👳 👲 🧕 🤵 👰 🤰 🤱
-👼 🎅 🤶 🦸 🦹 🧙 🧚 🧛 🧜 🧝
-🧞 🧟 💆 💇 🚶 🧍 🧎 🏃 💃 🕺
-🕴️ 👯 🧖 🧗 🤺 🏇 ⛷️ 🏂 🏌️ 🏄
-🚣 🏊 ⛹️ 🏋️ 🚴 🚵 🤸 🤼 🤽 🤾
-🤹 🧘 🛀 🛌 👭 👫 👬 💏 💑 👪"
 
-# Use fuzzel to display emoji selection
-selected_emoji=$(echo "$EMOJIS" | tr ' ' '\n' | fuzzel --dmenu --prompt="🔍 " --placeholder="Pick an emoji...")
+EMOJIS="$HOME/.cache/emojis.txt"
+EMOJI_URL="https://www.unicode.org/Public/emoji/latest/emoji-test.txt"
 
-# Copy to clipboard if an emoji was selected
-if [ -n "$selected_emoji" ]; then
-    echo -n "$selected_emoji" | wl-copy
-    notify-send "Emoji Picker" "Copied $selected_emoji to clipboard" 2>/dev/null || true
+mkdir -p "$(dirname "$EMOJIS")"
+
+# Download emoji list if it doesn't exist
+if [ ! -f "$EMOJIS" ]; then
+	echo "Fetching emoji list from unicode.org..."
+	curl -s "$EMOJI_URL" -o "$EMOJIS"
+fi
+
+# We grab only fully-qualified emojis and up to version 5.
+get_emojis() {
+	awk -F'# ' '/fully-qualified|component/ && /^[^#]/ {
+		if (match($2, / E([0-9\.]+)/, arr)) {
+			if (arr[1] + 0 <= 5.0) {
+				sub(/ E[0-9\.]+ /, " ");
+				print $2;
+			}
+		}
+}' "$EMOJIS"
+}
+
+# Use fuzzel to display emoji picker
+selected_line=$(get_emojis | fuzzel --dmenu --placeholder=" Search emojis...")
+
+# Copy selected emoji
+if [ -n "$selected_line" ]; then
+	selected_emoji=$(echo "$selected_line" | cut -d' ' -f1)
+
+	echo -n "$selected_emoji" | wl-copy
+	notify-send "Emoji Picker" "Copied $selected_emoji to clipboard"
 fi


### PR DESCRIPTION
Fixes the emoji picker by adding emoji names so it is properly searchable, and using the full list of emojis given by unicode.org. Solves issue #57.

This emoji picker implementation is not mine, it is essentially the same as @georgedobreff's PR [#68](https://github.com/malik-na/omarchy-mac/pull/68), which they closed citing that it was broken, but it seems to work just fine to me.