### PR TITLE
Make Neovim follow the active Omarchy theme

### DIFF
--- a/bin/omarchy-lazyvim-setup
+++ b/bin/omarchy-lazyvim-setup
@@ -29,4 +29,9 @@ git clone --depth=1 https://github.com/LazyVim/starter "$HOME/.config/nvim"
 # Remove .git to detach from upstream
 rm -rf "$HOME/.config/nvim/.git"
 
+# Wire LazyVim to follow the current Omarchy theme
+mkdir -p "$HOME/.config/nvim/lua/plugins"
+ln -sf "$HOME/.config/omarchy/current/theme/neovim.lua" \
+       "$HOME/.config/nvim/lua/plugins/omarchy-theme.lua"
+
 echo "[OK] LazyVim config installed to $HOME/.config/nvim"


### PR DESCRIPTION
Every theme ships `themes/<name>/neovim.lua` and `omarchy-theme-set` copies it to `~/.config/omarchy/current/theme/neovim.lua`, but nothing ever loads it — so Neovim stays on LazyVim's default colorscheme whatever you pick.

Symlink that file into `~/.config/nvim/lua/plugins/` during `omarchy-lazyvim-setup`. LazyVim picks it up like any other plugin, new nvim sessions follow the active theme. Mirrors the `current/theme/*` indirection already used for alacritty, kitty, waybar, etc.