### PR TITLE
Fix system/toggle/hardware menus showing one garbled line

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -59,6 +59,11 @@ menu() {
     fi
   fi
 
+  # Some callers build $options with literal "\n" via regular double-quoting
+  # instead of $'...' ANSI-C quoting. Expand those to real newlines so fuzzel
+  # gets one option per line.
+  options="${options//\\n/$'\n'}"
+
   # Keep Walker-style preselection behavior for compatibility.
   local list="$options"
   if [[ -n "$preselect" ]]; then


### PR DESCRIPTION
## Summary

The fuzzel-based `menu()` helper pipes options to fuzzel via `printf "%s\n" "$list"`, which does **not** interpret escape sequences. Several callers, however, build their option strings with regular double quotes and embed a literal `\n`:

```bash
# show_system_menu (bin/omarchy-menu)
local options="󱄄  Screensaver\n  Lock"
! omarchy-toggle-enabled suspend-off && options="$options\n󰒲  Suspend"
omarchy-hibernation-available && options="$options\n󰤁  Hibernate"
options="$options\n󰍃  Logout\n  Relaunch\n󰜉  Restart\n󰐥  Shutdown"
```

The result: fuzzel receives a single line containing the literal characters `\n`, so the user sees one garbled entry instead of a menu. On `Super+Esc` (System menu) only "Screensaver\n  Lock\n…" shows up.

The same shape exists in `show_toggle_menu`, `show_hardware_menu`, and `show_setup_system_menu`. Some sibling menus avoid the bug because they use `$'…'` ANSI-C quoting (e.g. `show_main_menu`, `show_style_menu`).

<img width="554" height="342" alt="image" src="https://github.com/user-attachments/assets/8b9ac684-9186-4152-a57a-9596b9dc0002" />

## Fix

Expand any literal `\n` to real newlines once, inside `menu()`, before downstream usage. Callers that already pass real newlines (via `$'...'`) are unaffected.

```bash
options="${options//\\n/$'\n'}"
```

This is a one-place fix that doesn't require touching every caller, and it keeps the door open for future call sites that aren't strict about quoting style.

<img width="554" height="1004" alt="image" src="https://github.com/user-attachments/assets/36a3adc7-ec8d-41b4-9eb3-94bd1803ea08" />

## Test plan
- [x] `Super+Esc` System menu shows Screensaver, Lock, Suspend, Logout, Relaunch, Restart, Shutdown on separate lines.
- [x] Toggle menu (Trigger → Toggle) shows all entries on separate lines.
- [x] Existing menus that build options with `$'...'` (Main, Style, Learn, Share, Screenrecord) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)