### PR TITLE
Fix /default/hypr/looknfeel.conf issues (Error parsing gradient -1 and dwindle:pseudotile)

### DIFF
--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -50,8 +50,8 @@ decoration {
 group {
     col.border_active = $activeBorderColor
     col.border_inactive = $inactiveBorderColor
-    col.border_locked_active = -1
-    col.border_locked_inactive = -1
+    col.border_locked_active = 0xff444444
+    col.border_locked_inactive = 0xff444444
 
     groupbar {
         font_size = 12

--- a/default/hypr/looknfeel.conf
+++ b/default/hypr/looknfeel.conf
@@ -109,9 +109,10 @@ animations {
 # https://wiki.hyprland.org/Configuring/Dwindle-Layout/
 dwindle {
     # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
-    pseudotile = yes # main split ratio, retained after child removed
     preserve_split = yes # you probably want this
 }
+
+pseudotile = yes # main split ratio, retained after child removed
 
 # https://wiki.hyprland.org/Configuring/Master-Layout/
 master {


### PR DESCRIPTION
Fix issues with hyprland configuration:
- Replace -1 with the hex value for transparency provided by the hypr website
- Move pseudotile out of the dwindle block as a global attribute.

Gradient value from new hyprland docs posted May 12, 2026: https://wiki.hypr.land/Configuring/Basics/Variables/#general

<img width="1888" height="1180" alt="image" src="https://github.com/user-attachments/assets/6d3e4a39-7c40-4898-9b46-431f1346ffa6" />
