### PR TITLE
Add one-time migration to redirect GitHub installs to Codeberg

### DIFF
--- a/migrations/1783870810.sh
+++ b/migrations/1783870810.sh
@@ -28,11 +28,31 @@ if ! git -C "$OMARCHY_PATH" fetch "$codeberg_url" main --tags; then
   exit 1
 fi
 
-# Preserve the pre-migration state before the hard reset.
+# Preserve the pre-migration state before the hard reset. The backup branch is
+# always cheap insurance; the stash + recovery note only matter if the user
+# actually had uncommitted local changes.
 git -C "$OMARCHY_PATH" branch -f pre-codeberg-migration HEAD 2>/dev/null || true
 if [[ -n "$(git -C "$OMARCHY_PATH" status --porcelain)" ]]; then
   git -C "$OMARCHY_PATH" stash push -u -m "pre-codeberg-migration" 2>/dev/null || true
-  echo "  local changes saved to git stash (\"pre-codeberg-migration\")"
+  recovery_note="$HOME/omarchy-codeberg-migration-recovery.txt"
+  cat >"$recovery_note" <<EOF
+Omarchy update source moved from GitHub to Codeberg.
+
+You had local changes in $OMARCHY_PATH. They were NOT discarded:
+  - your previous commit history is on branch 'pre-codeberg-migration'
+  - your uncommitted changes were saved to the git stash
+
+See what you had changed:
+  git -C "$OMARCHY_PATH" diff pre-codeberg-migration
+
+Restore your uncommitted changes (may conflict against the new Codeberg tree;
+the stash is kept if it does, so nothing is lost):
+  git -C "$OMARCHY_PATH" stash list
+  git -C "$OMARCHY_PATH" stash pop
+
+Delete this file once you're done.
+EOF
+  echo "  local changes stashed; recovery instructions written to $recovery_note"
 fi
 
 git -C "$OMARCHY_PATH" remote set-url origin "$codeberg_url"

--- a/migrations/1783870810.sh
+++ b/migrations/1783870810.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# One-time redirect: move installs still tracking the GitHub mirror onto the
+# canonical Codeberg source.
+#
+# GitHub main and Codeberg main have diverged (a few GitHub commits were lost
+# while the GitHub account was offline), so a plain pull would conflict — we
+# hard-reset onto Codeberg main instead. The current state is preserved on a
+# backup branch and any local changes are stashed first, so nothing is silently
+# discarded.
+
+codeberg_url="https://codeberg.org/malik-na/omarchy-mac.git"
+current="$(git -C "$OMARCHY_PATH" remote get-url origin 2>/dev/null || true)"
+
+case "$current" in
+  *github.com*omarchy-mac* | *github.com/basecamp/omarchy*) ;;
+  *)
+    echo "Origin is not a GitHub omarchy-mac remote ($current); leaving unchanged"
+    exit 0
+    ;;
+esac
+
+echo "Redirecting Omarchy updates from GitHub to Codeberg (was: $current)"
+
+# Fetch Codeberg FIRST — if it is unreachable, leave origin untouched so this
+# migration re-runs cleanly on the next update instead of stranding the install.
+if ! git -C "$OMARCHY_PATH" fetch "$codeberg_url" main --tags; then
+  echo "Could not reach Codeberg; will retry on next update." >&2
+  exit 1
+fi
+
+# Preserve the pre-migration state before the hard reset.
+git -C "$OMARCHY_PATH" branch -f pre-codeberg-migration HEAD 2>/dev/null || true
+if [[ -n "$(git -C "$OMARCHY_PATH" status --porcelain)" ]]; then
+  git -C "$OMARCHY_PATH" stash push -u -m "pre-codeberg-migration" 2>/dev/null || true
+  echo "  local changes saved to git stash (\"pre-codeberg-migration\")"
+fi
+
+git -C "$OMARCHY_PATH" remote set-url origin "$codeberg_url"
+git -C "$OMARCHY_PATH" reset --hard FETCH_HEAD # diverged histories: reset, don't merge
+
+echo -e "\e[32mMoved to the Codeberg source.\e[0m"
+echo "Previous state kept on branch 'pre-codeberg-migration'. Run 'omarchy update' once more to finish."


### PR DESCRIPTION
## Summary

A lot of installs still track the **GitHub** mirror, whose `main` has diverged from the canonical **Codeberg** source (a few GitHub commits were lost while the account was offline, so the two `main`s can no longer fast-forward or cleanly merge). This adds a **one-time Omarchy migration** that redirects those installs to Codeberg on their next `omarchy update`.

This is intentionally a **single-file, GitHub-only commit** — no force-push, no history rewrite, no Codeberg change. GitHub `main` just gains the redirect. New installs already clone from Codeberg via `boot.sh`; legacy installs get bounced once and then track Codeberg normally.

## How it works

On the next `omarchy update`, `omarchy-update-git` pulls this commit from GitHub, then `omarchy-migrate` runs the new migration, which:

1. Acts only if `origin` still looks like a GitHub `omarchy-mac` (or legacy `basecamp/omarchy`) remote — otherwise no-ops.
2. **Fetches Codeberg first.** If unreachable, it leaves `origin` untouched and exits non-zero so the migration retries cleanly on the next update rather than stranding the install.
3. Always stamps the current commit on a `pre-codeberg-migration` backup branch (cheap insurance).
4. **Only if the working tree is dirty:** stashes the uncommitted changes and writes `~/omarchy-codeberg-migration-recovery.txt` with the exact commands to inspect the backup branch and pop the stash. Pristine installs (the vast majority) get nothing extra.
5. Repoints `origin` to Codeberg and `git reset --hard` onto Codeberg `main` (diverged histories can't be merged cleanly).

It is naturally one-shot: the file does not exist on Codeberg `main`, so after the reset it disappears from the tree and never runs again; Codeberg users never see it.

## Why a recovery note

The migration's status lines scroll past during `omarchy update` (they only survive in `/tmp/omarchy-update.log`). For the small set of users who hand-edited the repo, a persistent `~/omarchy-codeberg-migration-recovery.txt` is far more discoverable. Nothing is destroyed regardless: committed state lives on the backup branch, and uncommitted state is in the stash (which `git stash pop` preserves even if it conflicts against the new Codeberg tree).

## Notes

- The migration timestamp (`1783870810`) sorts **after** all existing migrations, so it runs **last** — important, because it rewrites the working tree mid-run and must not disrupt sibling migrations.
- The redirect only takes effect for *future* pulls, so the current update finishes against the old tree; the next `omarchy update` (whenever the user runs it) then completes from Codeberg automatically. A message tells them to re-run.
- Guard is broad (`*github.com*omarchy-mac*` + `basecamp/omarchy`), so it also canonicalizes personal GitHub forks. Narrow it to `malik-na`/`basecamp` only if you'd rather leave forks alone.

## Testing

Validated locally against a fake diverged Codeberg/GitHub pair (no network):

- **Success path:** guard matches → Codeberg fetched → `pre-codeberg-migration` backup branch created at old HEAD → `origin` rewritten → `HEAD` reset exactly to Codeberg tip → GitHub-only commit removed, Codeberg-only commit present.
- **Dirty vs pristine:** dirty tree → changes stashed **and** recovery note written; clean tree → no stash, no note, backup branch only.
- **Stash recovery:** popping the stash onto the new Codeberg checkout applies cleanly for non-overlapping edits and produces normal conflict markers (stash preserved) for files Codeberg also changed.
- **Idempotency:** second run (origin now Codeberg) cleanly no-ops.
- **Failure path:** Codeberg unreachable → `origin` untouched, no backup branch, exit 1 → migration re-runs next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
