### PR TITLE
Make the omarchy-mac GitHub org the project's home

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Omarchy 4 on Apple Silicon, alongside macOS: Asahi Alarm + Omarchy, installed
 in one command, full-disk encryption included.
 
-[![License](https://img.shields.io/gitea/license/malik-na/omarchy-mac?gitea_url=https%3A%2F%2Fcodeberg.org)](LICENSE) [![Stars](https://img.shields.io/gitea/stars/malik-na/omarchy-mac?gitea_url=https%3A%2F%2Fcodeberg.org&style=social)](https://codeberg.org/malik-na/omarchy-mac/stargazers)
+[![License](https://img.shields.io/github/license/omarchy-mac/omarchy-mac)](LICENSE) [![Stars](https://img.shields.io/github/stars/omarchy-mac/omarchy-mac?style=social)](https://github.com/omarchy-mac/omarchy-mac/stargazers)
 
 Already running Omarchy 3.x? This page is the fresh install — to upgrade in
 place, see [docs/upgrade-to-quattro.md](docs/upgrade-to-quattro.md).
@@ -49,7 +49,7 @@ again.
 Still as root:
 
 ```bash
-curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-mac-setup | bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-mac-setup | bash
 ```
 
 There is nothing to prepare beyond the network: no pacman update, no locale
@@ -57,7 +57,7 @@ setup, no user creation. The script installs what it needs, creates your user
 and sets up sudo itself. To read it before running it, or to pass options:
 
 ```bash
-curl -LO https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-mac-setup
+curl -LO https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-mac-setup
 bash omarchy-mac-setup --no-encrypt
 ```
 
@@ -102,7 +102,7 @@ the minimal image ships without `git` or `sudo`, so as root first:
 `pacman -S --needed sudo git` — installing Omarchy itself is:
 
 ```bash
-git clone https://codeberg.org/malik-na/omarchy-mac.git ~/.local/share/omarchy
+git clone https://github.com/omarchy-mac/omarchy-mac.git ~/.local/share/omarchy
 cd ~/.local/share/omarchy
 cat version    # 4.x — if this says 3.x you are on the wrong branch
 bash install.sh

--- a/bin/omarchy-mac-setup
+++ b/bin/omarchy-mac-setup
@@ -41,14 +41,14 @@ LOG=/var/log/omarchy-mac-setup.log
 # branch that actually carries this script and the two tools it drives --
 # quattro, the repo's default branch. The check below still refuses to install
 # Omarchy 3 unasked when an older ref is passed explicitly.
-DEFAULT_REPO=malik-na/omarchy-mac
+DEFAULT_REPO=omarchy-mac/omarchy-mac
 DEFAULT_REF=quattro
 # The host the repo is fetched from. Overridable because the same repo is
 # mirrored on more than one forge, and an install should not be stopped by one
 # of them being unreachable -- which has happened: codeberg.org stopped
 # completing TCP handshakes mid-install. It is also the whole change needed if
 # the project's home moves.
-DEFAULT_FORGE=codeberg.org
+DEFAULT_FORGE=github.com
 
 # Everything this script shells out to, and therefore everything the chosen
 # branch has to contain.

--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -18,7 +18,7 @@ wires that checkout into the places a packaged install would occupy.
 
 This script is self-contained so 3.x users can run it directly:
 
-  curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/main/bin/omarchy-upgrade-to-quattro-mac | bash
+  curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-upgrade-to-quattro-mac | bash
 
 Options:
   -y, --yes      Do not prompt before upgrading

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -167,11 +167,11 @@ install_yay() {
 
 clone_repo_to_user() {
     local username="$1"
-    local repo="${OMARCHY_REPO:-malik-na/omarchy-mac}"
+    local repo="${OMARCHY_REPO:-omarchy-mac/omarchy-mac}"
     local ref="${OMARCHY_REF:-main}"
 
     print_step "Cloning Omarchy Mac into user's home"
-    su - "$username" -c "bash -lc 'set -e; mkdir -p ~/.local/share; rm -rf ~/.local/share/omarchy; git clone https://codeberg.org/${repo}.git ~/.local/share/omarchy; cd ~/.local/share/omarchy; if [[ \"${ref}\" != \"main\" ]]; then git fetch origin \"${ref}\" && git checkout \"${ref}\"; fi'"
+    su - "$username" -c "bash -lc 'set -e; mkdir -p ~/.local/share; rm -rf ~/.local/share/omarchy; git clone https://github.com/${repo}.git ~/.local/share/omarchy; cd ~/.local/share/omarchy; if [[ \"${ref}\" != \"main\" ]]; then git fetch origin \"${ref}\" && git checkout \"${ref}\"; fi'"
     print_success "Repository cloned"
 }
 

--- a/docs/btrfs.md
+++ b/docs/btrfs.md
@@ -41,7 +41,7 @@ onto the EFI partition, mounts the partition there instead of at `/boot/efi`,
 reinstalls GRUB with its prefix on that partition, and rebuilds the initramfs.
 
 ```bash
-curl -LO https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-system-boot-to-esp
+curl -LO https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-system-boot-to-esp
 sudo bash omarchy-system-boot-to-esp
 # reboot, confirm the machine still comes up, then encrypt
 ```
@@ -79,7 +79,7 @@ produces (`@fresh` in particular) is only meaningful on a fresh install.
 As root on the fresh install:
 
 ```bash
-curl -LO https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-system-btrfs-migrate
+curl -LO https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-system-btrfs-migrate
 bash omarchy-system-btrfs-migrate --encrypt   # omit --encrypt to stay unencrypted
 ```
 

--- a/docs/upgrade-to-quattro.md
+++ b/docs/upgrade-to-quattro.md
@@ -42,7 +42,7 @@ retires the old one.
 ## Run the upgrade
 
 ```bash
-curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-upgrade-to-quattro-mac | bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bin/omarchy-upgrade-to-quattro-mac | bash
 ```
 
 The script confirms before it changes anything, asks for your sudo password

--- a/manual/49-omarchy-on.md
+++ b/manual/49-omarchy-on.md
@@ -2,7 +2,7 @@
 
 ### Apple M1/M2 chips
 
-[Asahi Alarm](https://asahi-alarm.org/) is a version of Arch for Apple M1/M2 computers built on top of [Asahi Linux](https://asahilinux.org/). You can get Omarchy running on top of that with some effort. See [the user-driven guide](https://codeberg.org/malik-na/omarchy-mac).
+[Asahi Alarm](https://asahi-alarm.org/) is a version of Arch for Apple M1/M2 computers built on top of [Asahi Linux](https://asahilinux.org/). You can get Omarchy running on top of that with some effort. See [the user-driven guide](https://github.com/omarchy-mac/omarchy-mac).
 
 ### Apple Virtual Machine
 

--- a/migrations/1787417162.sh
+++ b/migrations/1787417162.sh
@@ -1,0 +1,18 @@
+echo "Point the Omarchy checkout at its new home on GitHub"
+
+# The project moved from codeberg.org/malik-na/omarchy-mac to the omarchy-mac
+# GitHub org. Updates fetch this checkout's tracking remote, so machines still
+# pointing at the old home follow the move. Only the old canonical URLs are
+# touched: forks and dev checkouts keep the origin they were given.
+
+checkout="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
+git -C "$checkout" rev-parse --is-inside-work-tree &>/dev/null || exit 0
+
+origin=$(git -C "$checkout" remote get-url origin 2>/dev/null || true)
+case "$origin" in
+  https://codeberg.org/malik-na/omarchy-mac | \
+  https://codeberg.org/malik-na/omarchy-mac.git | \
+  git@codeberg.org:malik-na/omarchy-mac.git)
+    git -C "$checkout" remote set-url origin https://github.com/omarchy-mac/omarchy-mac.git
+    ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -7,9 +7,9 @@
 # and guides the user to run the actual bootstrap script locally.
 #
 # Usage (as root after first boot):
-#   curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/main/bootstrap.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bootstrap.sh | bash
 #   OR
-#   wget -qO- https://codeberg.org/malik-na/omarchy-mac/raw/branch/main/bootstrap.sh | bash
+#   wget -qO- https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/bootstrap.sh | bash
 # =============================================================================
 
 set -e
@@ -74,7 +74,7 @@ check_root() {
 
 # Clone repository and setup
 clone_repository() {
-    local repo_url="https://codeberg.org/malik-na/omarchy-mac.git"
+    local repo_url="https://github.com/omarchy-mac/omarchy-mac.git"
     local target_dir="/root/.local/share/omarchy"
     
     print_step "Downloading Omarchy Mac repository..."

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -37,8 +37,8 @@ pass "Mac Quattro upgrade does not call the retired 3.x command names"
 
 # The curl one-liner is written out in both the script and the guide, so a
 # branch rename can leave a 3.x user fetching an upgrade that no longer exists.
-script_url=$(grep -oE 'https://codeberg.org/[^ ]*omarchy-upgrade-to-quattro-mac' "$upgrade_to_quattro_mac" | head -1)
-doc_url=$(grep -oE 'https://codeberg.org/[^ ]*omarchy-upgrade-to-quattro-mac' "$ROOT/docs/upgrade-to-quattro.md" | head -1)
+script_url=$(grep -oE 'https://[^ ]*omarchy-upgrade-to-quattro-mac' "$upgrade_to_quattro_mac" | head -1)
+doc_url=$(grep -oE 'https://[^ ]*omarchy-upgrade-to-quattro-mac' "$ROOT/docs/upgrade-to-quattro.md" | head -1)
 [[ -n $script_url && -n $doc_url ]] || fail "the upgrade one-liner appears in both the script and the guide"
 [[ $script_url == "$doc_url" ]] ||
   fail "the upgrade one-liner agrees between script and guide" "script: $script_url

--- a/tests/test-mac-setup.sh
+++ b/tests/test-mac-setup.sh
@@ -364,7 +364,7 @@ make_checkout() {
 
 co=$work/checkout
 
-make_checkout "$co" https://codeberg.org/scottjones/omarchy-mac.git feat/btrfs-encrypt-only tools
+make_checkout "$co" https://github.com/scottjones/omarchy-mac.git feat/btrfs-encrypt-only tools
 check "the right repo, branch and tools is reused" \
   checkout_matches "$co" scottjones/omarchy-mac feat/btrfs-encrypt-only
 
@@ -374,7 +374,7 @@ check "a different repo is replaced" \
   not checkout_matches "$co" malik-na/omarchy-mac feat/btrfs-encrypt-only
 
 # The case that actually happened: a 3.x tree from the refused run.
-make_checkout "$co" https://codeberg.org/malik-na/omarchy-mac.git main bare
+make_checkout "$co" https://github.com/omarchy-mac/omarchy-mac.git main bare
 check "the right branch without the tools is replaced" \
   not checkout_matches "$co" malik-na/omarchy-mac main
 


### PR DESCRIPTION
With quattro now the default branch here, this points everything the install and upgrade paths fetch at runtime to this repo: the setup script's defaults, the README and doc one-liners, the btrfs tool downloads, and the 3.x upgrade one-liner (which also makes the script and guide agree, fixing the red test). Badges switch to GitHub-native ones — the license badge finally renders, since Codeberg's API never reported a license. A migration repoints existing installs' git origin from Codeberg to this repo so their updates follow the move; forks and dev checkouts are untouched.

One sequencing note: these same commits must also land on Codeberg's quattro, since existing machines pull from Codeberg and need the migration to arrive there to learn about the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)