### PR TITLE
Fix GitHub Pages: auto-deploy on quattro push, serve wget one-liner

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,10 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [quattro]
+  schedule:
+    # Weekly safety net so the site can never drift far from quattro
+    - cron: "17 4 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -26,23 +29,21 @@ jobs:
 
       - name: Prepare site files
         run: |
-          mkdir -p _site
-          cp index.html _site/
-          cp install.sh _site/
-          cp boot.sh _site/
-          cp bootstrap.sh _site/
-          cp -r bin _site/
-          cp -r config _site/
-          cp -r default _site/
-          cp -r install _site/
-          cp -r migrations _site/
-          cp -r applications _site/
-          cp -r autostart _site/
-          cp version _site/
-          cp .nojekyll _site/
-          # Copy any additional assets
-          [ -f icon.png ] && cp icon.png _site/ || true
-          [ -f logo.svg ] && cp logo.svg _site/ || true
+          mkdir -p _site/bin _site/config _site/default _site/install _site/migrations _site/applications _site/docs
+          cp index.html README.md LICENSE version _site/
+          [[ -f install.sh ]] && cp install.sh _site/
+          [[ -f bootstrap.sh ]] && cp bootstrap.sh _site/
+          cp bin/omarchy-mac-setup _site/bin/
+          cp -r config/. _site/config/
+          cp -r default/. _site/default/
+          cp -r install/. _site/install/
+          cp -r migrations/. _site/migrations/
+          cp -r applications/. _site/applications/
+          [[ -d docs ]] && cp -r docs/. _site/docs/
+          [[ -d autostart ]] && cp -r autostart _site/
+          [[ -f .nojekyll ]] && cp .nojekyll _site/
+          # upload-pages-artifact dereferences symlinks; dangling ones make tar fail.
+          find _site -xtype l -delete
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -50,7 +51,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '_site'
+          path: "_site"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -49,15 +49,25 @@ again.
 Still as root:
 
 ```bash
-curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-mac-setup | bash
+wget -qO- https://omarchy-mac.github.io/omarchy-mac/bin/omarchy-mac-setup | bash
 ```
+
+This URL always serves the script from the current `quattro` branch — the site
+redeploys itself on every merge, so there is no separate page to maintain.
 
 There is nothing to prepare beyond the network: no pacman update, no locale
 setup, no user creation. The script installs what it needs, creates your user
-and sets up sudo itself. To read it before running it, or to pass options:
+and sets up sudo itself. If GitHub is unreachable, the same script comes from
+Codeberg:
 
 ```bash
-curl -LO https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-mac-setup
+curl -fsSL https://codeberg.org/malik-na/omarchy-mac/raw/branch/quattro/bin/omarchy-mac-setup | bash
+```
+
+To read it before running it, or to pass options:
+
+```bash
+wget -q https://omarchy-mac.github.io/omarchy-mac/bin/omarchy-mac-setup
 bash omarchy-mac-setup --no-encrypt
 ```
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
 </head>
 <body>
     <h1>Omarchy Mac</h1>
-    <p>Install:</p>
-    <code>wget -qO- https://malik-na.codeberg.page/omarchy-mac/boot.sh | bash</code>
+    <p>Omarchy 4 on Apple Silicon, in one command (run as root on a fresh Asahi Alarm install):</p>
+    <code>wget -qO- https://omarchy-mac.github.io/omarchy-mac/bin/omarchy-mac-setup | bash</code>
+    <p>Full guide: <a href="https://github.com/omarchy-mac/omarchy-mac">github.com/omarchy-mac/omarchy-mac</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The Pages site (https://omarchy-mac.github.io/omarchy-mac/) has been stale since Feb 2026 and no single-step `wget` install works:

- Pages was in **legacy branch mode**, serving the old `pages` branch with Omarchy 3 content (`version` = 3.3.3)
- The legacy entry point `boot.sh` 404s on the live site
- The Actions workflow could never deploy: legacy mode ignores workflows, and it triggered on `main` while the default branch is `quattro`
- The current one-command installer (`bin/omarchy-mac-setup`) was never served from Pages at all

## Changes

- `.github/workflows/pages.yml`: deploy from **quattro** via `actions/deploy-pages` on every push, plus a weekly cron safety net and `workflow_dispatch`
- Site now serves `bin/omarchy-mac-setup` at a stable URL along with README/docs/version
- `index.html`: landing page shows the working wget command
- `README.md`: primary install command is now
  ```bash
  wget -qO- https://omarchy-mac.github.io/omarchy-mac/bin/omarchy-mac-setup | bash
  ```
  Codeberg raw URL kept as a fallback mirror

## Already applied outside this PR

- Repo Pages setting flipped from `legacy` → `workflow` build type, so this workflow can actually deploy once merged.

## After merge

First push to quattro triggers the deploy automatically; the site then stays in sync forever — no manual page updates.