### PR TITLE
Fix Asahi bootstrap admin handoff

### DIFF
--- a/bin/omarchy-mac-setup
+++ b/bin/omarchy-mac-setup
@@ -176,6 +176,11 @@ current_hostname() {
   printf '%s' "$name"
 }
 
+valid_username() {
+  local name="$1"
+  [[ $name != "root" && $name =~ ^[a-z_][a-z0-9_-]*$ ]]
+}
+
 # RFC 1123: each dot-separated label is 1–63 characters of letters, digits and
 # hyphens, and cannot start or end with a hyphen. Dots are allowed so a fully
 # qualified name can be given.
@@ -771,18 +776,53 @@ lock_root_account() {
   fi
 }
 
+user_in_group() {
+  local user="$1" group="$2"
+  id -nG "$user" 2>/dev/null | tr ' ' '\n' | grep -qx "$group"
+}
+
+retire_asahi_admin() {
+  local owner="$1"
+
+  # Asahi Alarm's minimal image uses alarm as its bootstrap administrator.
+  # Once a different permanent owner has working sudo access, leaving alarm in
+  # wheel gives polkit two administrator identities and can make it ask for the
+  # bootstrap account's password instead of the active owner's.
+  [[ $owner != "alarm" ]] || return 0
+  id -u alarm >/dev/null 2>&1 || return 0
+  user_in_group alarm wheel || return 0
+
+  log "Removing the Asahi bootstrap account alarm from wheel"
+  gpasswd -d alarm wheel >/dev/null ||
+    fail "could not remove alarm from wheel; refusing to leave two administrators"
+}
+
 ensure_user() {
+  valid_username "$username" || fail "invalid owner username: $username"
   ensure_wheel_sudo
 
   if ! id -u "$username" >/dev/null 2>&1; then
     log "Creating user $username"
     useradd -m -G wheel -s /bin/bash "$username"
+  fi
+
+  # A pre-existing account may be locked or have no password. It is not ready
+  # to replace the bootstrap administrator until it can authenticate to sudo
+  # and polkit itself.
+  if ! user_has_password "$username"; then
     log "Set a password for $username:"
     until passwd "$username"; do
       warn "Try again."
     done
   fi
 
+  # Also cover a pre-existing owner. Previously only useradd granted wheel
+  # membership, even though the root account could still be locked afterwards.
+  usermod -aG wheel "$username"
+  user_in_group "$username" wheel ||
+    fail "$username is not in wheel; refusing to lock root or retire alarm"
+
+  retire_asahi_admin "$username"
   lock_root_account "$username"
 }
 
@@ -1125,7 +1165,7 @@ ask_questions() {
 
   while [[ -z $username ]]; do
     read -rp "Username to create (your everyday login): " username
-    [[ $username =~ ^[a-z_][a-z0-9_-]*$ ]] || {
+    valid_username "$username" || {
       warn "That is not a valid Linux username."
       username=""
     }

--- a/tests/test-mac-setup.sh
+++ b/tests/test-mac-setup.sh
@@ -181,6 +181,10 @@ check "answering no stops the run" refuses_to_start 'no
 echo
 echo "=== hostnames ==="
 
+check "a regular owner username is accepted" valid_username sfreiburg
+check "root is refused as the owner" not valid_username root
+check "a username beginning with a digit is refused" not valid_username 1owner
+
 valid() {
   valid_hostname "$1"
 }
@@ -577,6 +581,88 @@ matches() {
   local pattern="$1" text="$2"
   grep -qiE -- "$pattern" <<<"$text"
 }
+
+echo
+echo "=== retiring the Asahi bootstrap administrator ==="
+
+retirement_run() {
+  local owner="$1" alarm_exists="$2" alarm_in_wheel="$3" removal_ok=${4:-1}
+  (
+    id() {
+      [[ $1 == "-u" && $2 == "alarm" && $alarm_exists == 1 ]]
+    }
+    user_in_group() {
+      [[ $1 == "alarm" && $2 == "wheel" && $alarm_in_wheel == 1 ]]
+    }
+    gpasswd() {
+      printf 'GPASSWD: %s\n' "$*" >&2
+      [[ $removal_ok == 1 ]]
+    }
+    log() { :; }
+    retire_asahi_admin "$owner"
+  )
+}
+
+check "alarm is removed when a different owner takes over" \
+  matches 'GPASSWD: -d alarm wheel' "$(retirement_run sfreiburg 1 1 2>&1)"
+
+check "alarm remains an administrator when it is the chosen owner" \
+  not matches 'GPASSWD:' "$(retirement_run alarm 1 1 2>&1)"
+
+check "a missing alarm account needs no cleanup" \
+  not matches 'GPASSWD:' "$(retirement_run sfreiburg 0 0 2>&1)"
+
+check "an already-demoted alarm account needs no cleanup" \
+  not matches 'GPASSWD:' "$(retirement_run sfreiburg 1 0 2>&1)"
+
+failed_retirement_is_refused() {
+  ! retirement_run sfreiburg 1 1 0 >/dev/null 2>&1
+}
+
+check "a failed alarm demotion stops the handoff" failed_retirement_is_refused
+
+ensure_user_run() {
+  local existing="$1" has_password="$2"
+  (
+    username=owner
+    ensure_wheel_sudo() { :; }
+    id() { [[ $existing == 1 ]]; }
+    useradd() { echo USERADD; }
+    user_has_password() { [[ $has_password == 1 ]]; }
+    passwd() { echo PASSWD; return 0; }
+    usermod() { echo USERMOD; }
+    user_in_group() { return 0; }
+    retire_asahi_admin() { echo RETIRE_ALARM; }
+    lock_root_account() { echo LOCK_ROOT; }
+    log() { :; }
+    ensure_user
+  )
+}
+
+new_owner_run=$(ensure_user_run 0 0)
+existing_owner_run=$(ensure_user_run 1 1)
+passwordless_owner_run=$(ensure_user_run 1 0)
+
+check "a new owner is created and given a password before the handoff" \
+  [ "$new_owner_run" = $'USERADD\nPASSWD\nUSERMOD\nRETIRE_ALARM\nLOCK_ROOT' ]
+
+check "an existing owner keeps its password and is made an administrator" \
+  [ "$existing_owner_run" = $'USERMOD\nRETIRE_ALARM\nLOCK_ROOT' ]
+
+check "a passwordless existing owner gets a password before the handoff" \
+  [ "$passwordless_owner_run" = $'PASSWD\nUSERMOD\nRETIRE_ALARM\nLOCK_ROOT' ]
+
+root_owner_run=$(
+  (
+    username=root
+    ensure_wheel_sudo() { echo MUTATED; }
+    ensure_user
+  ) 2>&1
+)
+root_owner_status=$?
+
+check "root is rejected at the account-mutation boundary" [ "$root_owner_status" != "0" ]
+check "rejecting root happens before account mutation" not matches MUTATED "$root_owner_run"
 
 no_unbound_when_piped() { ! matches 'unbound variable' "$(piped --status)"; }
 piped_reaches_main() { matches 'Omarchy Mac setup status' "$(piped --status)"; }


### PR DESCRIPTION
## Summary

- ensure the selected owner has a usable password and verified `wheel` membership before retiring the bootstrap administrator
- remove `alarm` from `wheel` when a different permanent owner is selected, while keeping the account available for recovery
- reject `root` as the owner before any account mutation
- cover new, existing, passwordless, idempotent, and failure paths

Closes #191.

## Validation

- `bash -n bin/omarchy-mac-setup tests/test-mac-setup.sh`
- `bin/omarchy commands --check`
- syntax validation for every `bin/omarchy-*` command
- focused setup suite: 140 checks pass; one pre-existing host-dependent piped `--help` assertion fails
- `./test/all` completed with six unrelated baseline/environment failures (missing companion package checkout, locale/runtime assumptions, and existing style/system-path checks)

### Disposable container test

The account handoff was also exercised in an Ubuntu 24.04 ARM64 Docker container using the real `useradd`, `usermod`, `gpasswd`, `passwd`, and `id` implementations. The official Arch base image was attempted first but does not publish an ARM64 manifest.

The container test:

1. created a `wheel` group;
2. created the Asahi-style `alarm` bootstrap account and added it to `wheel`;
3. created a password-bearing `owner` account without `wheel`;
4. sourced this branch’s installer and ran `ensure_user` (stubbing only the host-specific sudoers write and root-lock operation);
5. asserted that `owner` gained `wheel`, `alarm` lost `wheel`, and the `alarm` account still existed.

Observed final state:

```text
Removing the Asahi bootstrap account alarm from wheel
owner_groups=owner wheel
alarm_groups=alarm
```

The container was launched with `docker run --rm`, so its filesystem and test accounts were removed automatically on exit.

## Review

The final revision received independent QA and code review. Both passed with no blocking findings.