### PR TITLE
Default the Mac Quattro upgrade to quattro and validate the tree before changes

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -54,7 +54,7 @@ confirm() {
 }
 
 checkout="$HOME/.local/share/omarchy"
-upgrade_ref="${OMARCHY_UPGRADE_REF:-main}"
+upgrade_ref="${OMARCHY_UPGRADE_REF:-quattro}"
 yes=0
 auto_reboot=0
 
@@ -132,6 +132,34 @@ switch_checkout_to_quattro() {
   git -C "$checkout" fetch origin "$upgrade_ref"
   git -C "$checkout" checkout "$upgrade_ref"
   git -C "$checkout" merge --ff-only "origin/$upgrade_ref"
+}
+
+# Refuses to continue unless the checked-out tree is Quattro. Without this a
+# wrong ref (the old default was main) got as far as installing packages and
+# writing under /usr and /etc before aborting on the first missing file.
+validate_quattro_tree() {
+  local path version
+
+  version=$(cat "$checkout/version" 2>/dev/null || echo unknown)
+  if [[ $version != 4.* ]]; then
+    fail "The '$upgrade_ref' tree at $checkout is not Quattro (version: $version). Use --ref quattro or unset OMARCHY_UPGRADE_REF."
+  fi
+
+  for path in \
+    etc/profile.d/omarchy.sh \
+    default/uwsm/env.d/10-omarchy \
+    default/environment.d/10-omarchy-fcitx.conf \
+    install/omarchy-base.packages; do
+    [[ -f $checkout/$path ]] ||
+      fail "The '$upgrade_ref' tree at $checkout is missing $path; it does not have the Quattro layout."
+  done
+
+  for path in omarchy-apply-system omarchy-provision-user; do
+    [[ -x $checkout/bin/$path ]] ||
+      fail "The '$upgrade_ref' tree at $checkout is missing bin/$path; it does not have the Quattro layout."
+  done
+
+  log "The '$upgrade_ref' tree at $checkout is Quattro ($version)"
 }
 
 install_quattro_packages() {
@@ -276,6 +304,7 @@ switch_to_networkmanager() {
 main() {
   backup_user_config
   switch_checkout_to_quattro
+  validate_quattro_tree
   install_quattro_packages
   wire_system_paths
   update_bashrc

--- a/docs/upgrade-to-quattro.md
+++ b/docs/upgrade-to-quattro.md
@@ -53,7 +53,8 @@ while — Quickshell and a few other AUR packages are compiled on the machine.
 
 1. Backs up `~/.config` to `~/.config.omarchy3.<timestamp>.bak`.
 2. Switches `~/.local/share/omarchy` to the `quattro` branch (it refuses to run
-   if the checkout has uncommitted changes).
+   if the checkout has uncommitted changes, and refuses to continue unless the
+   checked-out tree is a Quattro one).
 3. Installs the Quattro package set from `install/omarchy-base.packages` with
    yay, skipping the few upstream packages that are x86-only, and installs
    `wf-recorder` — Apple GPUs cannot run gpu-screen-recorder, so screen

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -35,6 +35,72 @@ if grep -qE 'omarchy-setup-system|omarchy-finalize-user' "$upgrade_to_quattro_ma
 fi
 pass "Mac Quattro upgrade does not call the retired 3.x command names"
 
+# Issue #200: the ref used to default to main, so a no-argument run checked out
+# 3.8.2, installed packages against it, and aborted mid-upgrade on the first
+# missing Quattro file — leaving the machine half-migrated.
+grep -F 'upgrade_ref="${OMARCHY_UPGRADE_REF:-quattro}"' "$upgrade_to_quattro_mac" >/dev/null ||
+  fail "Mac Quattro upgrade defaults to the quattro ref" "expected: upgrade_ref=\"\${OMARCHY_UPGRADE_REF:-quattro}\""
+pass "Mac Quattro upgrade defaults to the quattro ref"
+
+validate_body=$(function_body validate_quattro_tree)
+[[ -n $validate_body ]] || fail "the Mac Quattro upgrade validates the selected tree"
+
+# The validator must run after the checkout switch but before packages are
+# installed or anything under /usr and /etc is written.
+main_body=$(function_body main)
+[[ $main_body == *install_quattro_packages* ]] ||
+  fail "main still installs the Quattro package set"
+steps_before_install=${main_body%%install_quattro_packages*}
+[[ $steps_before_install == *switch_checkout_to_quattro* && $steps_before_install == *validate_quattro_tree* ]] ||
+  fail "the tree validator runs before any package or system changes"
+pass "the tree validator runs before any package or system changes"
+
+# Exercise the validator itself against fake trees: a 3.x tree must be rejected,
+# a Quattro-shaped one accepted. The function reads $checkout/$upgrade_ref and
+# reports through fail(), so stub that out for the extraction run.
+check_tree() {
+  local tree_version="$1" description="$2" expect="$3" drop_path="${4:-}" status workdir
+
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/bin" "$workdir/etc/profile.d" "$workdir/default/uwsm/env.d" \
+    "$workdir/default/environment.d" "$workdir/install"
+  printf '%s\n' "$tree_version" >"$workdir/version"
+  : >"$workdir/etc/profile.d/omarchy.sh"
+  : >"$workdir/default/uwsm/env.d/10-omarchy"
+  : >"$workdir/default/environment.d/10-omarchy-fcitx.conf"
+  : >"$workdir/install/omarchy-base.packages"
+  printf '#!/bin/bash\n' >"$workdir/bin/omarchy-apply-system"
+  printf '#!/bin/bash\n' >"$workdir/bin/omarchy-provision-user"
+  chmod +x "$workdir/bin/omarchy-apply-system" "$workdir/bin/omarchy-provision-user"
+  [[ -z $drop_path ]] || rm -f "$workdir/$drop_path"
+
+  status=0
+  (
+    checkout=$workdir
+    upgrade_ref=quattro
+    log() { :; }
+    fail() { printf 'Error: %s\n' "$*" >&2; exit 1; }
+    # function_body hands back the bare body; re-wrap it into a definition.
+    eval "validate_quattro_tree() {
+$validate_body
+}"
+    validate_quattro_tree
+  ) >/dev/null 2>&1 || status=$?
+  rm -rf "$workdir"
+
+  if [[ $expect == "reject" && $status == 0 ]]; then
+    fail "the tree validator rejects a non-Quattro tree ($description)"
+  elif [[ $expect == "accept" && $status != 0 ]]; then
+    fail "the tree validator accepts a Quattro tree ($description)" "exit status: $status"
+  fi
+}
+
+check_tree "3.8.2" "version 3.8.2" reject
+# The failure #200 reported: a 4.x-shaped version is not enough on its own.
+check_tree "4.0.0.alpha" "missing etc/profile.d/omarchy.sh" reject "etc/profile.d/omarchy.sh"
+check_tree "4.0.0.alpha" "version 4.0.0.alpha" accept
+pass "the tree validator only lets Quattro trees through"
+
 # The curl one-liner is written out in both the script and the guide, so a
 # branch rename can leave a 3.x user fetching an upgrade that no longer exists.
 script_url=$(grep -oE 'https://[^ ]*omarchy-upgrade-to-quattro-mac' "$upgrade_to_quattro_mac" | head -1)


### PR DESCRIPTION
Fixes #200

## Problem

The documented 3.x-to-Quattro one-liner piped a script whose ref defaulted to `main`:

```bash
upgrade_ref="${OMARCHY_UPGRADE_REF:-main}"
```

A no-argument run therefore switched `~/.local/share/omarchy` to `main` (3.8.2), installed packages against the 3.x tree, replaced `/usr/share/omarchy`, wrote `/etc/omarchy.conf`, and only then aborted on the first missing Quattro file (`etc/profile.d/omarchy.sh` and friends) — leaving the machine half-migrated, and rerunning selected `main` again.

## Fix

- Default `OMARCHY_UPGRADE_REF` to `quattro`, matching the option description, the upgrade guide, and the script's own name.
- Add a `validate_quattro_tree` preflight that runs after the checkout switch but **before** any package install or write under `/usr`, `/etc`, or the user's config. It requires:
  - a `version` file starting with `4.`
  - the Quattro system/profile files the later steps install
  - executable `bin/omarchy-apply-system` and `bin/omarchy-provision-user`
- Document the new refusal in the upgrade guide's step list.
- Regression tests: the no-arg default must be `quattro`; the validator must run between the checkout switch and package install; extracted-validator runs reject a 3.8.2 tree, reject a 4.x tree missing `etc/profile.d/omarchy.sh` (the failure #200 reported), and accept a full Quattro-shaped tree.

## QA

- `./test/shell.d/upgrade-to-quattro-mac-test.sh`: 7/7 pass (also passes under the full `./test/shell` run)
- Failure set of full shell + cli suites is identical to a pristine `quattro` worktree on this host (pre-existing macOS-environment failures plus one clipboard flake that passes on rerun)
- `bash -n` on changed scripts; `bin/omarchy commands --check` passes under bash 5
- Mutation check: reverting the default to `main` fails the suite