### PR TITLE
[FIX/Polkit] pam.d path fix in PolkitAgent.qml

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -158,7 +158,7 @@ Item {
     NumberAnimation { target: root; property: "shakeOffset"; to: 0; duration: 55; easing.type: Easing.OutQuad }
   }
   FileView {
-    path: "/etc/pam.d/polkit-1"
+    path: "/usr/lib/pam.d/polkit-1"
     watchChanges: true
     printErrors: false
     onLoaded: root.loadPamConfig(text())


### PR DESCRIPTION
## What does this PR do:

**Changes the path to `pam.d` directory, where the `polkit-1` is in fresh Arch release.**

## What does it for:

It keeps code _clean_ and _up to date_. Function `FileView` **didn't work** properly, affecting some of PolkitAgent.qml use cases.

## Steps to check:

1. update Asahi Alarm by **running**: `pacman -Syu`
2. **run:** `ls /etc/pam.d/polkit-1` 
**expected:** `"/etc/pam.d/polkit-1": No such file or directory (os error 2)` 
3. **run:** `ls /usr/lib/pam.d/polkit-1` 
**expected:** `.rw-r--r--   155 root  1 Jan 05:24  󰡯 /usr/lib/pam.d/polkit-1`